### PR TITLE
Windows ci Closes #7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
     - name: Install python packages
       run: |
         pipenv install --dev
-    - name: List system version
-      run: |
-        pipenv run sysver
     - name: Run tests
       run: |
         pipenv run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
         pip install pipenv
     - name: Install python packages
       run: |
-        pipenv install --verbose --dev
+        pipenv install --dev
+    - name: List system version
+        run: |
+          pipenv run sysver
     - name: Run tests
       run: |
         pipenv run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       matrix:
         # ubuntu-18.04 currently same as ubuntu-latest
-        # TODO: windows-latest (windows server 2019) fails at pipenv install when creating virtual env
-        os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
+        os: [ubuntu-16.04, ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v1
@@ -23,11 +22,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc musl-dev libxml2-dev libxslt-dev python-dev
       if: runner.os == 'Linux'
-    - name: Install dependencies
+    - name: Install pipenv
       run: |
         python -m pip install --upgrade pip
         pip install pipenv
-        pipenv install --dev
+    - name: Install python packages
+      run: |
+        pipenv install --verbose --dev
     - name: Run tests
       run: |
         pipenv run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       run: |
         pipenv install --dev
     - name: List system version
-        run: |
-          pipenv run sysver
+      run: |
+        pipenv run sysver
     - name: Run tests
       run: |
         pipenv run tests

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ ui = "python src/ui.py"
 tests = "python -m pytest tests"
 debug_tests = "python -m pytest -s tests"
 lint = "black ."
+sysver = "python -c 'import platform; print(platform.system())'"
 
 [dev-packages]
 black = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ lint = "black ."
 black = "*"
 rope = "*"
 pytest = "*"
+atomicwrites = "*"
 
 [packages]
 lxml = "==3.7.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "56283b40138dcfc339c1defcee3f30fc418e82749bf797b96b92d14a07eb0bb0"
+            "sha256": "65e42b81458cfdb44b61f18b916233940f3266a40be50cad97dfdc6868a12733"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -84,20 +84,20 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:21a8e19e2007a4047ffabbd8f0ee32c0dabae3b7f4b6c645110ae53e7714b470",
-                "sha256:74ad685bfb065f4bdd36d24aa97092f04bcbb1179b5ffdd3d5f994023fb8c292",
-                "sha256:79c3ba1da22e61c2a71aaa382c57518ab492278c8974c40187b900b50f3e0282",
-                "sha256:94ad913ab3fd967d14ecffda8182d7d0e1f7dd919b352773c492ec51890d3224",
-                "sha256:998db501e3a627c3e5678d6505f0e182d1529545df289db036cdc717f35d8058",
-                "sha256:9b69d4645bff5820713e8912bc61c4277dc127a6f8c197b52b6436503c42600f",
-                "sha256:9da13b536533518343a04f3c6564782ec8a13c705310b26b4832d77fa4d92a47",
-                "sha256:a76159f13b47fb44fb2acac8fef798a1940dd31b4acec6f4560bd11b2d92d31b",
-                "sha256:a9e9175c1e47a089a2b45d9e2afc6aae1f1f725538c32eec761894a42ba1227f",
-                "sha256:ea51ce7b96646ecd3bb12c2702e570c2bd7dd4d9f146db7fa83c5008ede35f66",
-                "sha256:ffbaaa05de60fc444eda3f6300d1af27d965b09b67f1fb4ebcc88dd0fb4ab1b4"
+                "sha256:059b2ee3194d718896c0ad077dd8c043e5e909d9180f387ce42012662a4946d6",
+                "sha256:1cf708e2ac57f3aabc87405f04b86354f66799c8e62c28c5fc5f88b5521b2dbf",
+                "sha256:24521fa2890642614558b492b473bee0ac1f8057a7263156b02e8b14c88ce6f5",
+                "sha256:4fee71aa5bc6ed9d5f116327c04273e25ae31a3020386916905767ec4fc5317e",
+                "sha256:70024e02197337533eef7b85b068212420f950319cc8c580261963aefc75f811",
+                "sha256:74782fbd4d4f87ff04159e986886931456a1894c61229be9eaf4de6f6e44b99e",
+                "sha256:940532b111b1952befd7db542c370887a8611660d2b9becff75d39355303d82d",
+                "sha256:cb1f2f5e426dc9f07a7681419fe39cee823bb74f723f36f70399123f439e9b20",
+                "sha256:dbbb2379c19ed6042e8f11f2a2c66d39cceb8aeace421bfc29d085d93eda3689",
+                "sha256:e3a057b7a64f1222b56e47bcff5e4b94c4f61faac04c7c4ecb1985e18caa3994",
+                "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
             ],
             "index": "pypi",
-            "version": "==5.3b1"
+            "version": "==5.3"
         }
     },
     "develop": {
@@ -107,6 +107,14 @@
                 "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
             ],
             "version": "==1.4.3"
+        },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [
@@ -147,10 +155,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
-                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+                "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb",
+                "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"
             ],
-            "version": "==19.2"
+            "version": "==20.0"
         },
         "pathspec": {
             "hashes": [
@@ -264,7 +272,8 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603"
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
             ],
             "version": "==0.1.8"
         },

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://github.com/ConorSheehan1/comp_corrector/workflows/ci/badge.svg)](https://github.com/ConorSheehan1/comp_corrector/actions/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ## Requirements
 1. python 3.6 [tkinter (not provided by pipenv)]  

--- a/src/file_management/compile.py
+++ b/src/file_management/compile.py
@@ -11,8 +11,7 @@ def _compile_cfile(
     file_path: str, cwd: str, compiler: str, capture_output: bool
 ) -> int:
     """
-    This function runs commands on the OS.
-    It tries to compile the file within cwd to handle relative imports.
+    This function tries to compile the file within cwd to handle relative imports.
     It returns the status code of the compile command.
     :param file_path:
     :param cwd: current working directory

--- a/src/file_management/zip_archives.py
+++ b/src/file_management/zip_archives.py
@@ -52,7 +52,7 @@ def setup_safe_mode(cwd: str, zip_path: str) -> Tuple[str, str]:
     :return: tuple of new safe dir and zip path
     """
     # make dir same name as zip (remove file extension, add slash)
-    safe_dirname = os.path.basename(zip_path).split(".")[0]
+    safe_dirname = os.path.splitext(os.path.basename(zip_path))[0]
     safe_cwd = os.path.join(cwd, safe_dirname)
     # create safe dir if it doesn't exist
     if not os.path.exists(safe_cwd):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -95,7 +95,7 @@ class TestMainSafeMode(unittest.TestCase):
 
         # gcc output always add .exe on windows
         if platform.system() == "Windows":
-            compiled_filed = f"{compiled_file}.exe"
+            compiled_file = f"{compiled_file}.exe"
 
         assert not os.path.exists(compiled_file)
         # hide output for tests

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -12,6 +12,7 @@ import unittest
 import os
 import shutil
 import re
+import platform
 
 # functions under test
 from src.file_management.zip_archives import unzip, unzip_outer, setup_safe_mode
@@ -91,9 +92,15 @@ class TestMainSafeMode(unittest.TestCase):
         """
         # compiled_file = self.example_student_code.replace(".c", "")
         compiled_file = re.sub(r"\.c$", "", self.example_student_code)
+
+        # gcc output always add .exe on windows
+        if platform.system() == "Windows":
+            compiled_filed = f"{compiled_file}.exe"
+
         assert not os.path.exists(compiled_file)
         # hide output for tests
         errors = compile_c(self.safe_cwd, capture_output=True)
+        assert errors == 1
         assert os.path.exists(compiled_file)
 
     def test_06_feedback(self):


### PR DESCRIPTION
Closes #7 

* Expect .exe file extensions for compiled files on windows.
* Split pipenv install into it's own step, see https://github.com/actions/runner/issues/258
* Add atomicwrites package for windows pytest, see https://docs.pytest.org/en/latest/changelog.html and https://github.com/pytest-dev/pytest/pull/6148
* Add black linter badge to readme.